### PR TITLE
Fix: Restrict website deployment action to changes to relevant files

### DIFF
--- a/.github/workflows/build-website.yml
+++ b/.github/workflows/build-website.yml
@@ -3,6 +3,9 @@ on:
   push:
     branches:
       - main
+    paths:
+      - 'docs/**'
+      - 'src/**'
 jobs:
   update-docs:
     runs-on: ubuntu-latest


### PR DESCRIPTION
I noticed the GH Action was running with any changes to other files which don't change the state of the site itself, e.g. see commit b2497798ced42be440dd4601f0ff9948dbd9295f. Not sure if src/ is also relevant, but I put it there just to be sure.