### PR TITLE
Add shared library header

### DIFF
--- a/src/Cpp/1-getting-started/2-HelloFroge/Main.cpp
+++ b/src/Cpp/1-getting-started/2-HelloFroge/Main.cpp
@@ -24,11 +24,7 @@ using Microsoft::WRL::ComPtr;
 #include <vector>
 #include <unordered_map>
 
-#pragma comment(lib, "d3d11.lib")
-#pragma comment(lib, "dxgi.lib")
-#pragma comment(lib, "d3dcompiler.lib")
-#pragma comment(lib, "winmm.lib")
-#pragma comment(lib, "dxguid.lib")
+#include "../Shared/CommonLibraries.h"
 
 template<UINT TDebugNameLength>
 inline void SetDebugName(_In_ ID3D11DeviceChild* deviceResource, _In_z_ const char(&debugName)[TDebugNameLength])

--- a/src/Cpp/1-getting-started/Shared/CommonLibraries.h
+++ b/src/Cpp/1-getting-started/Shared/CommonLibraries.h
@@ -1,10 +1,10 @@
 #pragma once
 
-// Main Direct3D11 library  https://docs.microsoft.com/en-us/windows/win32/direct3d11/atoc-dx-graphics-direct3d-11
+// Main Direct3D11 library https://docs.microsoft.com/en-us/windows/win32/direct3d11/atoc-dx-graphics-direct3d-11
 #pragma comment(lib, "d3d11.lib")
-// DXGI  https://docs.microsoft.com/en-us/windows/win32/direct3ddxgi/d3d10-graphics-programming-guide-dxgi
+// DXGI https://docs.microsoft.com/en-us/windows/win32/direct3ddxgi/d3d10-graphics-programming-guide-dxgi
 #pragma comment(lib, "dxgi.lib")
 // Runtime shader compilation https://docs.microsoft.com/en-us/windows/win32/api/d3dcompiler/
 #pragma comment(lib, "d3dcompiler.lib")
-// Collection of GUID's for usage with SetPrivateData and ComPtr
+// Collection of GUIDs for usage with SetPrivateData and ComPtr
 #pragma comment(lib, "dxguid.lib")

--- a/src/Cpp/1-getting-started/Shared/CommonLibraries.h
+++ b/src/Cpp/1-getting-started/Shared/CommonLibraries.h
@@ -1,0 +1,10 @@
+#pragma once
+
+// Main Direct3D11 library  https://docs.microsoft.com/en-us/windows/win32/direct3d11/atoc-dx-graphics-direct3d-11
+#pragma comment(lib, "d3d11.lib")
+// DXGI  https://docs.microsoft.com/en-us/windows/win32/direct3ddxgi/d3d10-graphics-programming-guide-dxgi
+#pragma comment(lib, "dxgi.lib")
+// Runtime shader compilation https://docs.microsoft.com/en-us/windows/win32/api/d3dcompiler/
+#pragma comment(lib, "d3dcompiler.lib")
+// Collection of GUID's for usage with SetPrivateData and ComPtr
+#pragma comment(lib, "dxguid.lib")


### PR DESCRIPTION
This will remove some duplication and visual bloat from all tutorial sections as well as organize all the used libraries in a single place.