### PR TITLE
forgot first virtual bool Load() in Application.hpp

### DIFF
--- a/docs/1-introduction/1-1-getting-started/1-1-1-hello-window.md
+++ b/docs/1-introduction/1-1-getting-started/1-1-1-hello-window.md
@@ -226,6 +226,7 @@ public:
 protected:
     virtual void Cleanup();
     virtual bool Initialize();
+    virtual bool Load() = 0;
     virtual void Render() = 0;
     virtual void Update() = 0;
 


### PR DESCRIPTION
I noticed the example had another inconsistency using
std::string_view vs std::string library