### PR TITLE
Add: Commit checker to enforce 100 line length

### DIFF
--- a/.github/workflows/docs-checker.yml
+++ b/.github/workflows/docs-checker.yml
@@ -1,0 +1,24 @@
+name: Docs checker
+on:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - 'docs/**'
+jobs:
+  validate-line-length:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - name: Make sure git is installed
+        run: apt-get update && apt-get install git -y && git --version
+        # "https://google.com/serch"
+
+        # The first grep filters out everything that has a link in it. The second filters anything
+        # that is not an addition (prefixed by a single '+').
+      - name: Get changed file names of files changed in PR
+        run: git diff -U0 ${{ github.event.pull_request.base.sha }} ${{ github.sha }} | grep -P "^(?!.*(http|ftp|https):\/\/([\w_-]+(?:(?:\.[\w_-]+)+))([\w.,@?^=%&:\/~+#-]*[\w@?^=%&\/~+#-])).*" | grep -P "^\+{1}(?!\+)" > diff_files.txt
+      - name: Count line lengths in diff_files.txt
+        run: "awk -F: 'BEGIN { if(length>100) { err = 1; exit; } } END {exit err}' diff_files.txt"


### PR DESCRIPTION
Enforcing 100 line length should be beneficial for everyone. Shorter lines increase readability on smaller screens and on GitHub, as you cannot wrap your lines in the browser.

I'm not exactly sure if this actually works, but this is roughly how it works:
1. It uses `git diff` and `grep` to extract every single added/changed line.
2. It uses grep to filter lines that include links, as those are prone to being far longer than 100 chars.
3. Small `awk` script to check the length of each line, and return a non-zero exit code if any line is longer than 100.

Not sure if the usage of the GitHub commit SHA1 variables is correct, and I'm also not sure if the `awk` exit code works as I think it does. Can anyone verify this?