### PR TITLE
Fixes #100 : Use row major matrices rather than the default column major matrices

### DIFF
--- a/src/Cpp/1-getting-started/1-3-2-LoadingMeshes-Refactored/Assets/Shaders/Main.vs.hlsl
+++ b/src/Cpp/1-getting-started/1-3-2-LoadingMeshes-Refactored/Assets/Shaders/Main.vs.hlsl
@@ -14,25 +14,25 @@ struct VSOutput
 
 cbuffer PerApplication
 {
-    matrix ProjectionMatrix;
+    row_major matrix ProjectionMatrix;
 }
 
 cbuffer PerFrame
 {
-    matrix ViewMatrix;
+    row_major matrix ViewMatrix;
 }
 
 cbuffer PerObject
 {
-    matrix WorldMatrix;
+    row_major matrix WorldMatrix;
 }
 
 VSOutput Main(VSInput input)
 {
-    const matrix modelViewProjection = mul(ProjectionMatrix, mul(ViewMatrix, WorldMatrix));
+    const matrix modelViewProjection = mul(WorldMatrix, mul(ViewMatrix, ProjectionMatrix));
 
     VSOutput output = (VSOutput)0;
-    output.Position = mul(modelViewProjection, float4(input.Position, 1.0f));
+    output.Position = mul(float4(input.Position, 1.0f), modelViewProjection);
     output.Color = input.Color;
     output.Uv = input.Uv;
     return output;

--- a/src/Cpp/1-getting-started/1-3-2-LoadingMeshes/Assets/Shaders/Main.vs.hlsl
+++ b/src/Cpp/1-getting-started/1-3-2-LoadingMeshes/Assets/Shaders/Main.vs.hlsl
@@ -14,25 +14,25 @@ struct VSOutput
 
 cbuffer PerApplication : register(b0)
 {
-    matrix ProjectionMatrix;
+    row_major matrix ProjectionMatrix;
 }
 
 cbuffer PerFrame : register(b1)
 {
-    matrix ViewMatrix;
+    row_major matrix ViewMatrix;
 }
 
 cbuffer PerObject : register(b2)
 {
-    matrix WorldMatrix;
+    row_major matrix WorldMatrix;
 }
 
 VSOutput Main(VSInput input)
 {
-    const matrix modelViewProjection = mul(ProjectionMatrix, mul(ViewMatrix, WorldMatrix));
+    const matrix modelViewProjection = mul(WorldMatrix, mul(ViewMatrix, ProjectionMatrix));
 
     VSOutput output = (VSOutput)0;
-    output.Position = mul(modelViewProjection, float4(input.Position, 1.0f));
+    output.Position = mul(float4(input.Position, 1.0f), modelViewProjection);
     output.Color = input.Color;
     output.Uv = input.Uv;
     return output;

--- a/src/Cpp/1-getting-started/1-3-3-DearImGui/Assets/Shaders/Main.vs.hlsl
+++ b/src/Cpp/1-getting-started/1-3-3-DearImGui/Assets/Shaders/Main.vs.hlsl
@@ -14,25 +14,25 @@ struct VSOutput
 
 cbuffer PerApplication
 {
-    matrix ProjectionMatrix;
+    row_major matrix ProjectionMatrix;
 }
 
 cbuffer PerFrame
 {
-    matrix ViewMatrix;
+    row_major matrix ViewMatrix;
 }
 
 cbuffer PerObject
 {
-    matrix WorldMatrix;
+    row_major matrix WorldMatrix;
 }
 
 VSOutput Main(VSInput input)
 {
-    const matrix modelViewProjection = mul(ProjectionMatrix, mul(ViewMatrix, WorldMatrix));
+    const matrix modelViewProjection = mul(WorldMatrix, mul(ViewMatrix, ProjectionMatrix));
 
     VSOutput output = (VSOutput)0;
-    output.Position = mul(modelViewProjection, float4(input.Position, 1.0f));
+    output.Position = mul(float4(input.Position, 1.0f), modelViewProjection);
     output.Color = input.Color;
     output.Uv = input.Uv;
     return output;

--- a/src/Cpp/1-getting-started/1-3-4-DepthBuffer/Assets/Shaders/Main.vs.hlsl
+++ b/src/Cpp/1-getting-started/1-3-4-DepthBuffer/Assets/Shaders/Main.vs.hlsl
@@ -14,25 +14,25 @@ struct VSOutput
 
 cbuffer PerApplication
 {
-    matrix ProjectionMatrix;
+    row_major matrix ProjectionMatrix;
 }
 
 cbuffer PerFrame
 {
-    matrix ViewMatrix;
+    row_major matrix ViewMatrix;
 }
 
 cbuffer PerObject
 {
-    matrix WorldMatrix;
+    row_major matrix WorldMatrix;
 }
 
 VSOutput Main(VSInput input)
 {
-    const matrix modelViewProjection = mul(ProjectionMatrix, mul(ViewMatrix, WorldMatrix));
+    const matrix modelViewProjection = mul(WorldMatrix, mul(ViewMatrix, ProjectionMatrix));
 
     VSOutput output = (VSOutput)0;
-    output.Position = mul(modelViewProjection, float4(input.Position, 1.0f));
+    output.Position = mul(float4(input.Position, 1.0f), modelViewProjection);
     output.Color = input.Color;
     output.Uv = input.Uv;
     return output;

--- a/src/Cpp/1-getting-started/1-3-5-RasterizerState/Assets/Shaders/Main.vs.hlsl
+++ b/src/Cpp/1-getting-started/1-3-5-RasterizerState/Assets/Shaders/Main.vs.hlsl
@@ -14,17 +14,17 @@ struct VSOutput
 
 cbuffer PerApplication
 {
-    column_major matrix ProjectionMatrix;
+    row_major matrix ProjectionMatrix;
 }
 
 cbuffer PerFrame
 {
-    column_major matrix ViewMatrix;
+    row_major matrix ViewMatrix;
 }
 
 cbuffer PerObject
 {
-    column_major matrix WorldMatrix;
+    row_major matrix WorldMatrix;
 }
 
 VSOutput Main(VSInput input)
@@ -32,7 +32,7 @@ VSOutput Main(VSInput input)
     const matrix modelViewProjection = mul(WorldMatrix, mul(ViewMatrix, ProjectionMatrix));
 
     VSOutput output = (VSOutput)0;
-    output.Position = mul(modelViewProjection, float4(input.Position, 1.0f));
+    output.Position = mul(float4(input.Position, 1.0f), modelViewProjection);
     output.Color = input.Color;
     output.Uv = input.Uv;
     return output;

--- a/src/Cpp/1-getting-started/1-3-5-RasterizerState/Main.cpp
+++ b/src/Cpp/1-getting-started/1-3-5-RasterizerState/Main.cpp
@@ -2,7 +2,7 @@
 
 int main()
 {
-    RasterizerStateApplication app{ "LearnD3D11 - Depth Buffer" };
+    RasterizerStateApplication app{ "LearnD3D11 - Rasterizer State" };
     app.Run();
     return 0;
 }

--- a/src/Cpp/1-getting-started/1-3-6-Camera/Main.cpp
+++ b/src/Cpp/1-getting-started/1-3-6-Camera/Main.cpp
@@ -2,7 +2,7 @@
 
 int main()
 {
-    CameraApplication app{ "LearnD3D11 - Depth Buffer" };
+    CameraApplication app{ "LearnD3D11 - Camera" };
     app.Run();
     return 0;
 }


### PR DESCRIPTION
Use row major matrices rather than the default column major matrices in the vertex shaders. Also fixed incorrect window title names in the RasterizerState(1-3-5) and Camera(1-3-6) chapter source codes.